### PR TITLE
Add support for SW5e and open path for more systems support

### DIFF
--- a/module.json
+++ b/module.json
@@ -65,6 +65,14 @@
                 "compatibility": {
                     "verified": "2.0.2"
                 }
+            },
+            {
+              "id": "sw5e",
+              "type": "system",
+              "manifest": "https://github.com/unrealkakeman89/sw5e/releases/download/2.0.3.2.3.7/system.json",
+              "compatibility": {
+                "verified": "2.0.3.2.3.7"
+              }
             }
         ],
         "requires": [

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -29,7 +29,7 @@ export class MODULE {
     }
 
     static globals() {
-        game.dnd5e.covercalc = {};
+        game[game.system.id].covercalc = {};
     }
 
     static settings() {

--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -390,7 +390,7 @@ export class CoverCalculator {
     */
     static _patchToken() {
         Token.prototype.ignoresCover = function() {
-            let flagValue = this.actor?.getFlag("dnd5e", "helpersIgnoreCover") ?? 0;
+            let flagValue = this.actor?.getFlag(game.system.id, "helpersIgnoreCover") ?? 0;
             if (flagValue === true||flagValue === "true"){
                 // used to be a boolean flag, if the flag is true either 
                 // ,the value or a string due to AE shenanigans, treat is as it would have been before

--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -137,7 +137,7 @@ export class CoverCalculator {
 
         MODULE.applySettings(menuData);
 
-        CONFIG.DND5E.characterFlags.helpersIgnoreCover = {
+        CONFIG[game.system.id.toUpperCase()].characterFlags.helpersIgnoreCover = {
             hint: HELPER.localize("SCC.flagsNoCoverHint"),
             name: HELPER.localize("SCC.flagsNoCover"),
             section: "Feats",

--- a/scripts/modules/CoverCalculatorTokenSizes.js
+++ b/scripts/modules/CoverCalculatorTokenSizes.js
@@ -82,7 +82,7 @@ export class CoverCalculatorTokenSizes {
     }
 
     static userDefined() {
-        let keys = Object.keys(CONFIG.DND5E.tokenSizes)
+        let keys = Object.keys(CONFIG[game.system.id.toUpperCase()].tokenSizes)
 
         let noCover = HELPER.setting(MODULE.data.name, "noCoverTokenSizes").split(",")
         for (let size of noCover) {


### PR DESCRIPTION
This commit adds support for the SW5e system be replacing specific references to dnd5e with more general references to the current system.

This change should also open the way to supporting other systems, which, provided they are similar enough to dnd5e, will just require being added to the module.json