### PR TITLE
Add flag that allows reducing target cover by specified number of steps

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -80,8 +80,8 @@
     "SCC.flagsNoCoverOptionThreeQ" : "Ignore half and three-quarters cover.",
     "SCC.flagsNoCoverOptionFull" : "Ignore all cover.",
 
-    "SCC.flagsReduceCover" : "Reduces partial cover of targets by the given number of steps",
-    "SCC.flagsReduceCoverHint" : "Provided by feats and magic items.",
+    "SCC.flagsReduceCover" : "Reduce target partial cover",
+    "SCC.flagsReduceCoverHint" : "When attacking a target, their partial cover is reduced by the specified number of steps.",
 
     "setting.proneActsLikeDead.name": "Prone acts like 0 HP",
     "setting.proneActsLikeDead.hint": "When the token has the prone or unconcious status effect, handle cover as if it has 0 HP."

--- a/lang/en.json
+++ b/lang/en.json
@@ -80,6 +80,9 @@
     "SCC.flagsNoCoverOptionThreeQ" : "Ignore half and three-quarters cover.",
     "SCC.flagsNoCoverOptionFull" : "Ignore all cover.",
 
+    "SCC.flagsReduceCover" : "Reduces partial cover of targets by the given number of steps",
+    "SCC.flagsReduceCoverHint" : "Provided by feats and magic items.",
+
     "setting.proneActsLikeDead.name": "Prone acts like 0 HP",
     "setting.proneActsLikeDead.hint": "When the token has the prone or unconcious status effect, handle cover as if it has 0 HP."
 }

--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -682,10 +682,11 @@ class Cover {
 
         this.data.results.raw = results;
         this.data.results.ignore = this.data.origin.object.ignoresCover();
+        this.data.results.coverReduction = this.data.origin.object.reducesCover();
         this.data.results.corners = 0;
         this.data.results.cover = results.reduce((a,b) => Math.min(a, b.reduce((c,d) => Math.min(c, d.total), 3)),3);
         // Reduce cover by reduce value
-        this.data.cover = Math.max(0, this.data.results.cover - this.data.results.reduce);
+        this.data.cover = Math.max(0, this.data.results.cover - this.data.results.coverReduction);
 
         // If the current cover value is under the ignore threshold set cover to 0. ignore threshold goes from 1 to 3, cover from 0 to 3
         // none, half, threequarter, full

--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -150,6 +150,13 @@ export class CoverCalculator {
             type: Number
         };
 
+        CONFIG[game.system.id.toUpperCase()].characterFlags.helpersReduceCover = {
+            hint: HELPER.localize("SCC.flagsReduceCoverHint"),
+            name: HELPER.localize("SCC.flagsReduceCover"),
+            section: "Feats",
+            type: Number
+        };
+
         /* insert keybindings */
         game.keybindings.register(MODULE.data.name, "coverReport", {
             name: "Check Cover",
@@ -397,6 +404,10 @@ export class CoverCalculator {
                 flagValue=MODULE[NAME].ignoreCover.threeQuarter
             }
             return flagValue;
+        }
+
+        Token.prototype.reducesCover = function() {
+            return this.actor?.getFlag(game.system.id, "helpersReduceCover") ?? 0;
         }
 
         Token.prototype.coverValue = function() {
@@ -673,7 +684,10 @@ class Cover {
         this.data.results.ignore = this.data.origin.object.ignoresCover();
         this.data.results.corners = 0;
         this.data.results.cover = results.reduce((a,b) => Math.min(a, b.reduce((c,d) => Math.min(c, d.total), 3)),3);
-        // If the current cover value is under the ignore threshold set cover to 0. ignore theshold goes from 1 to 3, cover from 0 to 3
+        // Reduce cover by reduce value
+        this.data.cover = Math.max(0, this.data.results.cover - this.data.results.reduce);
+
+        // If the current cover value is under the ignore threshold set cover to 0. ignore threshold goes from 1 to 3, cover from 0 to 3
         // none, half, threequarter, full
         this.data.results.cover = this.data.results.cover <= this.data.results.ignore ? 0 : this.data.results.cover;
         this.data.results.label = MODULE[NAME].coverData[this.data.results.cover ?? 0].label;

--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -686,7 +686,7 @@ class Cover {
         this.data.results.corners = 0;
         this.data.results.cover = results.reduce((a,b) => Math.min(a, b.reduce((c,d) => Math.min(c, d.total), 3)),3);
         // Reduce cover by reduce value
-        this.data.cover = Math.max(0, this.data.results.cover - this.data.results.coverReduction);
+        this.data.results.cover = Math.max(0, this.data.results.cover - this.data.results.coverReduction);
 
         // If the current cover value is under the ignore threshold set cover to 0. ignore threshold goes from 1 to 3, cover from 0 to 3
         // none, half, threequarter, full


### PR DESCRIPTION
SW5e has modifiers that reduces cover by 1 level, instead of ignoring up to a level (for an example see: [The sharpshooter Fighting Style](https://sw5e.com/characters/customizationOptions/fightingStyles/?search=Sharpshooter%20Style)).

This PR adds a flag, `helpersReduceCover` that reduces their target's cover by a configured amount.

### Remaining work:
Only English language has been setup for the new flag, and the readme probably needs updating with the new feature.