### PR TITLE
Replace deprecated method of accessing tile data

### DIFF
--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -259,7 +259,7 @@ export class CoverCalculator {
     }
 
     static _renderTileConfig(app, html){
-        if (HELPER.setting(MODULE.data.name, "losSystem") === 0 || !HELPER.setting(MODULE.data.name, "losWithTiles") || app.object.data.overhead ) return;
+        if (HELPER.setting(MODULE.data.name, "losSystem") === 0 || !HELPER.setting(MODULE.data.name, "losWithTiles") || app.object.overhead ) return;
         const adjacentElement = html.find('[data-tab="basic"] .form-group').last();
         CoverCalculator._injectCoverAdjacent(app, html, adjacentElement);
     }


### PR DESCRIPTION
Foundry shows a deprecation warning for this line, I've applied the recommended fix and removed the warning.

I had a look around the rest of the codebase and I'm pretty sure it's the only occurrence.