### PR TITLE
Linked Tokens disregarded from check in CoverCalculatorTokenSizes.js

### DIFF
--- a/scripts/modules/CoverCalculatorTokenSizes.js
+++ b/scripts/modules/CoverCalculatorTokenSizes.js
@@ -151,13 +151,13 @@ export class CoverCalculatorTokenSizes {
     static isDowned(status) {
         return (
             status === CoverCalculatorTokenSizes.Downed.Prone &&
-            !token.actor.effects.find(eff => eff.data.label === CoverCalculatorTokenSizes.Downed.Unconscious) && 
-            !token.actor.getRollData().attributes.hp.value === 0
+            !token.actor.effects.find(eff => eff.label === CoverCalculatorTokenSizes.Downed.Unconscious) && 
+            !token.actor.system.attributes.hp.value === 0
         ) ||
         (
             status === CoverCalculatorTokenSizes.Downed.Unconscious &&
-            !token.actor.effects.find(eff => eff.data.label === CoverCalculatorTokenSizes.Downed.Prone) && 
-            !token.actor.getRollData().attributes.hp.value === 0
+            !token.actor.effects.find(eff => eff.label === CoverCalculatorTokenSizes.Downed.Prone) && 
+            !token.actor.system.attributes.hp.value === 0
         );
 }
 
@@ -175,7 +175,7 @@ export class CoverCalculatorTokenSizes {
     }    
 
     static async _preUpdateActor(actor, update) {
-        if (!actor.token || !actor.getActiveTokens()[0]?.document) return;
+        if (!actor.token && !actor.getActiveTokens()[0]?.document) return;
 
         let hp = getProperty(update, "system.attributes.hp.value");
         let token = actor.token ?? actor.getActiveTokens()[0].document;
@@ -191,7 +191,7 @@ export class CoverCalculatorTokenSizes {
     static async _preCreateActiveEffect(effect) {
         if (HELPER.setting(MODULE.data.name, 'proneActsLikeDead') === false) return;
 
-        if (!effect.parent.parent || !effect.parent.getActiveTokens()[0]?.document) return;
+        if (!effect.parent.parent && !effect.parent.getActiveTokens()[0]?.document) return;
 
         let status = effect.label;
         let token = effect.parent.parent ?? effect.parent.getActiveTokens()[0].document;
@@ -205,7 +205,7 @@ export class CoverCalculatorTokenSizes {
     static async _preDeleteActiveEffect(effect) {
         if (HELPER.setting(MODULE.data.name, 'proneActsLikeDead') === false) return;
 
-        if (!effect.parent.parent || !effect.parent.getActiveTokens()[0]?.document) return;
+        if (!effect.parent.parent && !effect.parent.getActiveTokens()[0]?.document) return;
 
         let status = effect.label;
         let token = effect.parent.parent ?? effect.parent.getActiveTokens()[0].document;


### PR DESCRIPTION
I think you implemented some changes I had made to the original Kandashi's Dnd5e Helpers Cover Expansion module for Lukas.

This inadvertently introduced a bug, by opting out of checking for the `TokenDocument#5e` existence if the `Actor#5e` is linked.
Changing the `||` in the conditionals to `&&` fixes this as it should only `return` if both are undefined.

Changes included: 
- `&&` instead of `||` in the conditionals.
- Removal of `data` from `eff.data.label` check to stop deprecation warnings.
- Use of `system` instead of the `getRollData()` method.

I can split it in different PRs if you feel it's better that way (or feel free to close this and implement them as you please 👍)