### PR TITLE
Update CoverCalculator.js

### DIFF
--- a/scripts/modules/CoverCalculator.js
+++ b/scripts/modules/CoverCalculator.js
@@ -555,12 +555,12 @@ export class CoverCalculator {
             // Dead
             if (
                 this.actor?.system.attributes.hp.value <= 0
-                || this.actor?.effects.find(eff => eff.label === HELPER.setting(MODULE.data.name, "unconsciousStatusName"))
+                || this.actor?.effects.find(eff => eff.name ?? eff.label === HELPER.setting(MODULE.data.name, "unconsciousStatusName"))
             ) return this.document.getFlag(MODULE.data.name, MODULE[NAME].flagDead) ?? 1;
 
             // Prone
             if (
-                this.actor?.effects.find(eff => eff.label === HELPER.setting(MODULE.data.name, "proneStatusName"))
+                this.actor?.effects.find(eff => eff.name ?? eff.label === HELPER.setting(MODULE.data.name, "proneStatusName"))
             ) return this.document.getFlag(MODULE.data.name, MODULE[NAME].flagProne) ?? 1;
 
             // Normal


### PR DESCRIPTION
Change to `eff.name ?? eff.label` so that it will stop throwing deprecation warnings.

Should help with https://github.com/vtt-lair/simbuls-cover-calculator/issues/60